### PR TITLE
[BUGFIX] Fix fatal errors on Documentation rendering

### DIFF
--- a/Documentation/Media/Index.rst
+++ b/Documentation/Media/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: ../../Includes.txt
+.. include:: ../Includes.txt
 
 
 .. _cobj-media:

--- a/Documentation/Multimedia/Index.rst
+++ b/Documentation/Multimedia/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: ../../Includes.txt
+.. include:: ../Includes.txt
 
 
 .. _cobj-multimedia:

--- a/Documentation/Qtobject/Index.rst
+++ b/Documentation/Qtobject/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: ../../Includes.txt
+.. include:: ../Includes.txt
 
 
 .. _cobj-qtobject:

--- a/Documentation/Swfobject/Index.rst
+++ b/Documentation/Swfobject/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: ../../Includes.txt
+.. include:: ../Includes.txt
 
 
 .. _cobj-swfobject:


### PR DESCRIPTION
Fix four errors. 

During documentation rendering, each of these lines causes a severe error with "No such file or directory". These errors are the reason, why there currently is no documentation rendered at https://docs.typo3.org/typo3cms/extensions/mediace 
