### PR TITLE
[BUGFIX] Fix issue: #21 wizard in flexform

### DIFF
--- a/Configuration/FlexForms/media.xml
+++ b/Configuration/FlexForms/media.xml
@@ -225,9 +225,9 @@
 										<title>LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:flexform.browseUrlTitle</title>
 										<icon>EXT:mediace/Resources/Public/Images/FormFieldWizard/wizard_link.gif</icon>
 										<module type="array">
-											<name>wizard_element_browser</name>
+											<name>wizard_link</name>
 											<urlParameters type="array">
-												<mode>file</mode>
+												<mode>file|url</mode>
 											</urlParameters>
 										</module>
 										<params type="array">
@@ -274,9 +274,9 @@
 														<title>LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:flexform.browseUrlTitle</title>
 														<icon>EXT:mediace/Resources/Public/Images/FormFieldWizard/wizard_link.gif</icon>
 														<module type="array">
-															<name>wizard_link_browser</name>
+															<name>wizard_link</name>
 															<urlParameters type="array">
-																<act>file</act>
+																<mode>file|url</mode>
 															</urlParameters>
 														</module>
 														<params type="array">
@@ -307,9 +307,9 @@
 										<title>LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:flexform.browseUrlTitle</title>
 										<icon>EXT:mediace/Resources/Public/Images/FormFieldWizard/wizard_link.gif</icon>
 										<module type="array">
-											<name>wizard_link_browser</name>
+											<name>wizard_link</name>
 											<urlParameters type="array">
-												<act>file</act>
+												<mode>file|url</mode>
 											</urlParameters>
 										</module>
 										<params type="array">
@@ -345,9 +345,9 @@
 														<title>LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:flexform.browseUrlTitle</title>
 														<icon>EXT:mediace/Resources/Public/Images/FormFieldWizard/wizard_link.gif</icon>
 														<module type="array">
-															<name>wizard_link_browser</name>
+															<name>wizard_link</name>
 															<urlParameters type="array">
-																<act>file</act>
+																<mode>file|url</mode>
 															</urlParameters>
 														</module>
 														<params type="array">
@@ -390,9 +390,9 @@
 										<title>LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:flexform.browseUrlTitle</title>
 										<icon>EXT:mediace/Resources/Public/Images/FormFieldWizard/wizard_link.gif</icon>
 										<module type="array">
-											<name>wizard_link_browser</name>
+											<name>wizard_link</name>
 											<urlParameters type="array">
-												<act>file</act>
+												<mode>file|url</mode>
 											</urlParameters>
 										</module>
 										<params type="array">
@@ -428,9 +428,9 @@
 														<title>LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:flexform.browseUrlTitle</title>
 														<icon>EXT:mediace/Resources/Public/Images/FormFieldWizard/wizard_link.gif</icon>
 														<module type="array">
-															<name>wizard_link_browser</name>
+															<name>wizard_link</name>
 															<urlParameters type="array">
-																<act>file</act>
+																<mode>file|url</mode>
 															</urlParameters>
 														</module>
 														<params type="array">


### PR DESCRIPTION
1. Fix wizard in Tab "HTML5 Additions" for the fields
"Video sources for HTML5 <video> element" and
"audio description for videos"

2. Allow external URLs like it was allowed in TYPO3 6.2