### PR TITLE
Fix deprecated defaultExtras

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -96,7 +96,7 @@ if (!is_array($GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverr
     $GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext'] = array();
 }
 if (version_compare(TYPO3_version, '8.7', '<')) {
-$GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext']['defaultExtras'] = $baseDefaultExtrasOfBodytext . 'nowrap';
+    $GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext']['defaultExtras'] = $baseDefaultExtrasOfBodytext . 'nowrap';
 } else {
     $GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext']['config']['wrap'] = 'off';
 }

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -80,7 +80,8 @@ if (!is_array($GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides'
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext'])) {
     $GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext'] = array();
 }
-$GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext']['defaultExtras'] = $baseDefaultExtrasOfBodytext . 'richtext:rte_transform[mode=ts_css]';
+$GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext']['config']['enableRichtext'] = '1';
+$GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext']['config']['richtextConfiguration'] = 'default';
 
 $GLOBALS['TCA']['tt_content']['palettes']['multimediafiles'] = array(
     'showitem' => 'multimedia;LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:tt_content.multimedia_formlabel, bodytext;LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:tt_content.bodytext',
@@ -91,7 +92,7 @@ if (!is_array($GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverr
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext'])) {
     $GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext'] = array();
 }
-$GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext']['defaultExtras'] = $baseDefaultExtrasOfBodytext . 'nowrap';
+$GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext']['config']['wrap'] = 'off';
 
 
 // Add flexform

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -80,9 +80,12 @@ if (!is_array($GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides'
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext'])) {
     $GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext'] = array();
 }
-$GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext']['config']['enableRichtext'] = '1';
-$GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext']['config']['richtextConfiguration'] = 'default';
-
+if (version_compare(TYPO3_version, '8.7', '<')) {
+    $GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext']['defaultExtras'] = $baseDefaultExtrasOfBodytext . 'richtext:rte_transform[mode=ts_css]';
+} else {
+    $GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext']['config']['enableRichtext'] = '1';
+    $GLOBALS['TCA']['tt_content']['types']['media']['columnsOverrides']['bodytext']['config']['richtextConfiguration'] = 'default';
+}
 $GLOBALS['TCA']['tt_content']['palettes']['multimediafiles'] = array(
     'showitem' => 'multimedia;LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:tt_content.multimedia_formlabel, bodytext;LLL:EXT:mediace/Resources/Private/Language/locallang.xlf:tt_content.bodytext',
 );
@@ -92,8 +95,11 @@ if (!is_array($GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverr
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext'])) {
     $GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext'] = array();
 }
-$GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext']['config']['wrap'] = 'off';
-
+if (version_compare(TYPO3_version, '8.7', '<')) {
+$GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext']['defaultExtras'] = $baseDefaultExtrasOfBodytext . 'nowrap';
+} else {
+    $GLOBALS['TCA']['tt_content']['types']['multimedia']['columnsOverrides']['bodytext']['config']['wrap'] = 'off';
+}
 
 // Add flexform
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue('*', 'FILE:EXT:mediace/Configuration/FlexForms/media.xml', 'media');

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
 	"license": ["GPL-2.0+"],
 
 	"require": {
-		"typo3/cms-core": "~7.6.0",
-		"typo3/cms-frontend": "~7.6.0"
+		"typo3/cms-core": "~7.6.0 || ~8.7.0",
+		"typo3/cms-frontend": "~7.6.0 || ~8.7.0"
 	},
 	"replace": {
 		"mediace": "*"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = array(
     'version' => '7.6.4',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '7.6.0-7.6.99',
+            'typo3' => '7.6.0-8.7.99',
         ),
         'conflicts' => array(),
         'suggests' => array(),


### PR DESCRIPTION
Fix deprecations as pointed out by the Install Tool:

> RTE configuration via 'defaultExtras' options are deprecated. String "richtext:rte_transform[mode=ts_css]" in TCA tt_content['types']['media']['columnsOverrides']['bodytext']['defaultExtras'] was changed to options in tt_content['columns']['bodytext']['config']
> 
> The defaultExtras setting 'nowrap' in TCA table tt_content['types']['multimedia']['columnsOverrides']['bodytext'] has been migrated to TCA table tt_content['types']['multimedia']['columnsOverrides']['bodytext']['config']['wrap'] = 'off'
> 